### PR TITLE
check if MOUNTPOIT exists before rmdir, redundant but more secure

### DIFF
--- a/cryptshot.sh
+++ b/cryptshot.sh
@@ -149,10 +149,8 @@ then
             umount $MOUNTPOINT
             # If the volume was unmounted and the user has requested that the
             # mount point be removed, remove it.
-            if [ $? -eq 0 ] && [ $REMOVEMOUNT -ne 0 ]; then
-                if [ -d $MOUNTPOINT ];then 
-                   rmdir $MOUNTPOINT
-                fi
+            if [ $? -eq 0 ] && [ $REMOVEMOUNT -ne 0 ] && [ -d $MOUNTPOINT ]; then
+                rmdir $MOUNTPOINT
             fi
         else
             exitcode=$?

--- a/cryptshot.sh
+++ b/cryptshot.sh
@@ -150,7 +150,9 @@ then
             # If the volume was unmounted and the user has requested that the
             # mount point be removed, remove it.
             if [ $? -eq 0 ] && [ $REMOVEMOUNT -ne 0 ]; then
-                rmdir $MOUNTPOINT
+                if [ -d $MOUNTPOINT ];then 
+                   rmdir $MOUNTPOINT
+                fi
             fi
         else
             exitcode=$?


### PR DESCRIPTION
As comment says, this is redundant but more secure, imho. 
Nice script!